### PR TITLE
Add the financials menu back in.

### DIFF
--- a/src/components/controls/menus/custodian-menu.vue
+++ b/src/components/controls/menus/custodian-menu.vue
@@ -41,7 +41,6 @@
             class="text-text1 text-weight-light"
           />
         </q-item>
-        <!--
         <q-item
           class="q-pl-lg animate-fade"
           link
@@ -52,7 +51,6 @@
             class="text-text1 text-weight-light"
           />
         </q-item>
-        -->
       </div>
     </q-collapsible>
 
@@ -85,6 +83,7 @@
             class="text-text1 text-weight-light"
           />
         </q-item>
+        -->
         <q-item
           class="q-pl-lg animate-fade"
           link
@@ -95,7 +94,6 @@
             class="text-text1 text-weight-light"
           />
         </q-item>
-        -->
       </div>
     </q-collapsible>
   </div>

--- a/src/components/controls/menus/main-menu.vue
+++ b/src/components/controls/menus/main-menu.vue
@@ -87,7 +87,7 @@ export default {
   name: "MainMenu",
   components: {
     custodianMenu,
-//    memberMenu,
+    //    memberMenu,
     devMenu,
     menuExtension
   },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -80,14 +80,12 @@ let routes = [
         component: () => import("pages/custodian/my-payments"),
         beforeEnter: Guards.custodianCheck
       },
-      /*
       {
         path: "dac-financials",
         component: () => import("pages/custodian/dac-financials")
       }
-      */
     ]
-/*
+    /*
   },
   {
     path: "/member",


### PR DESCRIPTION
Tested locally. Seems correct.

As a custodian:

![image](https://user-images.githubusercontent.com/344748/56987379-45dfc680-6b5b-11e9-842b-c48f2d3b195d.png)

Not logged in and logged in as a non-custodian:

![image](https://user-images.githubusercontent.com/344748/56987422-5a23c380-6b5b-11e9-9073-c84ea3bdd466.png)
