### PR TITLE
Updated master from dev

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -143,7 +143,8 @@ module.exports = function (ctx) {
         'QStepper',
         'QStep',
         'QStepperNavigation',
-        'QDatetimePicker'
+        'QDatetimePicker',
+        'QTooltip'
       ],
       directives: [
         'Ripple',

--- a/src/components/controls/msig-creator.vue
+++ b/src/components/controls/msig-creator.vue
@@ -221,15 +221,38 @@
               </div>
             </div>
             <div class="col-xs-12">
-              <div class="full-height">
-                <q-input
+              <div class="full-height text-text1">
+                <div class="q-mb-xs  q-caption">
+                  {{ $t("msig_creator.summary") }}
+                </div>
+                <MarkdownViewer
+                  :tags="[
+                    'h1',
+                    'h2',
+                    'h3',
+                    'italic',
+                    'bold',
+                    'underline',
+                    'strikethrough',
+                    'subscript',
+                    'superscript',
+                    'anchor',
+                    'orderedlist',
+                    'unorderedlist'
+                  ]"
+                  :edit="true"
+                  :dark="getIsDark"
+                  :text="msig_description"
+                  v-on:update="updateText"
+                />
+                <!-- <q-input
                   type="textarea"
                   :max-height="200"
                   :dark="getIsDark"
                   v-model="msig_description"
                   :stack-label="$t('msig_creator.summary')"
                   :placeholder="$t('msig_creator.sum_placeholder')"
-                />
+                /> -->
               </div>
             </div>
           </div>
@@ -447,6 +470,7 @@ import actionMaker from "components/controls/action-maker";
 import displayAction from "components/ui/display-action";
 import { date } from "quasar";
 import draggable from "vuedraggable";
+import MarkdownViewer from "components/ui/markdown-viewer";
 const today = new Date();
 const { addToDate } = date;
 const msigTrx_template = {
@@ -468,7 +492,8 @@ export default {
     debugData,
     actionMaker,
     displayAction,
-    draggable
+    draggable,
+    MarkdownViewer
   },
   data() {
     return {
@@ -529,6 +554,9 @@ export default {
   },
 
   methods: {
+    updateText(val) {
+      this.msig_description = val;
+    },
     handleSelection(index) {
       this.allow_advanced = false;
       this.controlled_accounts = this.controlled_accounts.map(ca => {

--- a/src/components/controls/msig-creator.vue
+++ b/src/components/controls/msig-creator.vue
@@ -615,12 +615,6 @@ export default {
     },
 
     getRequested() {
-      // let requested = this.getCustodians.map(c => {
-      //   let req = { actor: c.cust_name, permission: "active" };
-      //   return req;
-      // });
-      // console.log(requested);
-      // return requested;
       let number_requested = 24;
       let requested = this.getCandidates.slice(0, number_requested).map(c => {
         return { actor: c.candidate_name, permission: "active" };

--- a/src/components/controls/msig-creator.vue
+++ b/src/components/controls/msig-creator.vue
@@ -522,7 +522,8 @@ export default {
       getCustodians: "dac/getCustodians",
       getIsDark: "ui/getIsDark",
       getAuth: "user/getAuth",
-      getCandidates: "dac/getCandidates"
+      getCandidates: "dac/getCandidates",
+      getCustodianConfig: "dac/getCustodianConfig"
     }),
     parseNumberToAsset(number, symbol) {
       return `${number.toFixed(4)} ${symbol}`;
@@ -615,7 +616,7 @@ export default {
     },
 
     getRequested() {
-      let number_requested = 24;
+      let number_requested = this.getCustodianConfig.numelected * 2;
       let requested = this.getCandidates.slice(0, number_requested).map(c => {
         return { actor: c.candidate_name, permission: "active" };
       });

--- a/src/components/controls/msig-creator.vue
+++ b/src/components/controls/msig-creator.vue
@@ -521,7 +521,8 @@ export default {
       getAccountName: "user/getAccountName",
       getCustodians: "dac/getCustodians",
       getIsDark: "ui/getIsDark",
-      getAuth: "user/getAuth"
+      getAuth: "user/getAuth",
+      getCandidates: "dac/getCandidates"
     }),
     parseNumberToAsset(number, symbol) {
       return `${number.toFixed(4)} ${symbol}`;
@@ -614,11 +615,17 @@ export default {
     },
 
     getRequested() {
-      let requested = this.getCustodians.map(c => {
-        let req = { actor: c.cust_name, permission: "active" };
-        return req;
+      // let requested = this.getCustodians.map(c => {
+      //   let req = { actor: c.cust_name, permission: "active" };
+      //   return req;
+      // });
+      // console.log(requested);
+      // return requested;
+      let number_requested = 24;
+      let requested = this.getCandidates.slice(0, number_requested).map(c => {
+        return { actor: c.candidate_name, permission: "active" };
       });
-      console.log(requested);
+      console.log("requested signatures", requested);
       return requested;
     },
 

--- a/src/components/controls/network-switcher.vue
+++ b/src/components/controls/network-switcher.vue
@@ -97,8 +97,4 @@ export default {
 
 <style lang="stylus">
 @import '~variables';
-
-.modal-content {
-  // background-color: var(--q-color-warning);
-}
 </style>

--- a/src/components/ui/balance-timeline.vue
+++ b/src/components/ui/balance-timeline.vue
@@ -113,7 +113,7 @@ export default {
           {
             label: `${query.account} ${query.symbol}`,
             data: res.results.map(p => p.balance.split(" ")[0]),
-
+            lineTension: 0,
             backgroundColor: this.getGradient(),
             borderColor: colors.getBrand("primary"),
             pointBackgroundColor: "none",

--- a/src/components/ui/display-custodians.vue
+++ b/src/components/ui/display-custodians.vue
@@ -2,8 +2,9 @@
   <div class="row justify-between " v-if="custodians.length">
     <div
       class="column items-center q-pa-sm animate-fade"
-      v-for="custodian in custodians"
-      :key="custodian.cust_name"
+      v-for="(custodian, i) in custodians"
+      :key="`cust_${i}`"
+      @mouseover="showing = true"
     >
       <profile-pic
         :accountname="custodian.cust_name"
@@ -16,6 +17,10 @@
       >
         <div class="q-ma-none">{{ custodian.cust_name }}</div>
       </router-link>
+      <q-tooltip v-model="custodian.tooltip" class="bg-bg2">
+        <div>Votes: {{ custodian.total_votes / 10000 }}</div>
+        <div>Pay: {{ custodian.requestedpay }}</div>
+      </q-tooltip>
     </div>
   </div>
 </template>
@@ -36,7 +41,8 @@ export default {
 
   data() {
     return {
-      custodians: []
+      custodians: [],
+      showing: false
     };
   },
 
@@ -54,7 +60,10 @@ export default {
       } else {
         custodians = this.getCustodians;
       }
-      this.custodians = custodians;
+      this.custodians = custodians.map(c => {
+        c.tooltip = false;
+        return c;
+      });
     }
   },
 

--- a/src/components/ui/msig-proposal.vue
+++ b/src/components/ui/msig-proposal.vue
@@ -457,7 +457,7 @@
               <profile-pic
                 :accountname="c.actor"
                 :scale="0.5"
-                :show_role="false"
+                :show_role="true"
               />
               <router-link class=" a2" :to="{ path: '/profile/' + c.actor }">
                 <div class="q-ma-none" style="min-width:100px; overflow:hidden">
@@ -481,7 +481,7 @@
               <profile-pic
                 :accountname="c.actor"
                 :scale="0.5"
-                :show_role="false"
+                :show_role="true"
               />
               <router-link class=" a2" :to="{ path: '/profile/' + c.actor }">
                 <div class="q-ma-none" style="min-width:100px; overflow:hidden">
@@ -546,11 +546,21 @@ export default {
     read_only: function() {
       return !this.getIsCustodian;
     },
+    getCustodianApprovals() {
+      let cust_names = this.getCustodians.map(c => c.cust_name);
+      let custodian_approvals = this.provided_approvals.filter(pa =>
+        cust_names.includes(pa.actor)
+      );
+      return custodian_approvals;
+    },
 
     isExecutable: function() {
       if (this.provided_approvals) {
-        return this.provided_approvals.length >= this.msig.threshold;
-        // return this.provided_approvals.length > 0;
+        let cust_names = this.getCustodians.map(c => c.cust_name);
+        let custodian_approvals = this.provided_approvals.filter(pa =>
+          cust_names.includes(pa.actor)
+        );
+        return custodian_approvals.length >= this.msig.threshold;
       } else {
         return false;
       }
@@ -619,17 +629,17 @@ export default {
         ...this.msig.requested_approvals.map(a => a.actor)
       ]);
 
-      let cust_names = this.getCustodians.map(c => c.cust_name);
+      // let cust_names = this.getCustodians.map(c => c.cust_name);
 
       this.provided_approvals = this.msig.provided_approvals
-        .filter(ra => cust_names.includes(ra.actor))
+        // .filter(ra => cust_names.includes(ra.actor))
         .map(pa => {
           pa.avatar = avatars.find(p => p.account === pa.actor);
           return pa;
         });
 
       this.requested_approvals = this.msig.requested_approvals
-        .filter(ra => cust_names.includes(ra.actor))
+        // .filter(ra => cust_names.includes(ra.actor))
         .map(ra => {
           ra.avatar = avatars.find(p => p.account === ra.actor);
           return ra;

--- a/src/components/ui/msig-proposal.vue
+++ b/src/components/ui/msig-proposal.vue
@@ -326,6 +326,16 @@
                   }}</q-item-tile>
                 </q-item-main>
               </q-item>
+              <q-item class="no-padding q-ml-md">
+                <q-item-main>
+                  <q-item-tile class="text-text1 q-caption" label
+                    >Proposal ID</q-item-tile
+                  >
+                  <q-item-tile class="text-text1" sublabel>{{
+                    msig.proposal_name
+                  }}</q-item-tile>
+                </q-item-main>
+              </q-item>
             </div>
 
             <div

--- a/src/components/ui/msig-proposal.vue
+++ b/src/components/ui/msig-proposal.vue
@@ -153,8 +153,25 @@
               </div>
 
               <div class="q-mb-xs">
-                <div>Description:</div>
-                <div class="text-text2">{{ msig.description }}</div>
+                <div>Description</div>
+                <MarkdownViewer
+                  :tags="[
+                    'h1',
+                    'h2',
+                    'h3',
+                    'italic',
+                    'bold',
+                    'underline',
+                    'strikethrough',
+                    'subscript',
+                    'superscript',
+                    'anchor',
+                    'orderedlist',
+                    'unorderedlist'
+                  ]"
+                  :dark="getIsDark"
+                  :text="msig.description"
+                />
               </div>
               <div>
                 <div>
@@ -255,7 +272,6 @@
           </q-item-side>
           <q-item-main>
             <div class="q-ml-lg">
-              <!-- <div class="q-title q-mb-xs"><span class="text-text1">{{msig.proposal_name}}:</span> {{msig.title}}</div> -->
               <div class="q-body-3 q-mb-xs text-text1 capitalize">
                 {{ msig.title }}
               </div>
@@ -266,10 +282,10 @@
                     {{ msig.proposer }}
                   </router-link>
                 </div>
-                <div>
+                <div class="q-mt-xs">
                   <span class="text-text2"
                     >Submitted on:&nbsp;<span class="text-text1">{{
-                      new Date(msig.block_timestamp).toDateString()
+                      new Date(msig.block_timestamp).toUTCString()
                     }}</span></span
                   >
                 </div>
@@ -299,31 +315,56 @@
 
         <div class="q-px-md q-pb-md">
           <div style="border-top: 1px solid grey">
-            <div class="q-mt-md text-text1">Description</div>
-            <div class=" q-mb-md">{{ msig.description }}</div>
-            <div class="q-mt-md text-text1">Expiration</div>
-            <div class=" q-mb-md">
-              {{ new Date(msig.trx.expiration).toString() }}
+            <div class="row q-mt-md">
+              <q-item class="no-padding">
+                <q-item-main>
+                  <q-item-tile class="text-text1 q-caption" label
+                    >Expiration</q-item-tile
+                  >
+                  <q-item-tile class="text-text1" sublabel>{{
+                    new Date(msig.trx.expiration).toUTCString()
+                  }}</q-item-tile>
+                </q-item-main>
+              </q-item>
             </div>
-            <div class="q-mt-md text-text1">
-              Actions
-              <span class="text-text2">({{ msig.trx.actions.length }})</span>
+
+            <div
+              class="row justify-between q-mt-md q-mb-sm text-text1 q-caption"
+            >
+              <span>Description</span>
+              <div>
+                <span>trx: </span>
+                <a
+                  target="_blank"
+                  :href="
+                    $configFile.get('explorer') + `/transaction/${msig.trxid}`
+                  "
+                  class="q-body-1"
+                  >{{ msig.trxid.substring(0, 8) }}</a
+                >
+              </div>
             </div>
-            <div class="q-mb-md">
-              {{ msig.trx.actions.map(a => a.name).join(", ") }}
-            </div>
-            <div style="text-align:right">
-              <span>trx: </span>
-              <a
-                target="_blank"
-                :href="
-                  $configFile.get('explorer') + `/transaction/${msig.trxid}`
-                "
-                class="q-body-1"
-                >{{ msig.trxid.substring(0, 8) }}</a
-              >
-            </div>
-            <div class="bg-dark q-mb-md">
+            <MarkdownViewer
+              :tags="[
+                'h1',
+                'h2',
+                'h3',
+                'italic',
+                'bold',
+                'underline',
+                'strikethrough',
+                'subscript',
+                'superscript',
+                'anchor',
+                'orderedlist',
+                'unorderedlist'
+              ]"
+              :dark="getIsDark"
+              :text="msig.description"
+              class="bg-bg2"
+            />
+
+            <div class="bg-dark q-my-md">
               <Actionparser
                 @seenAllActions="disable_approve = false"
                 :actions="msig.trx.actions"
@@ -450,13 +491,15 @@
 <script>
 import Actionparser from "components/ui/action-parser";
 import profilePic from "components/ui/profile-pic";
+import MarkdownViewer from "components/ui/markdown-viewer";
 
 import { mapGetters } from "vuex";
 export default {
   name: "Msigproposal",
   components: {
     Actionparser,
-    profilePic
+    profilePic,
+    MarkdownViewer
   },
 
   props: {
@@ -485,7 +528,8 @@ export default {
       getMsigIsSeenCache: "user/getMsigIsSeenCache",
       getIsCustodian: "user/getIsCustodian",
       getSettingByName: "user/getSettingByName",
-      getAuth: "user/getAuth"
+      getAuth: "user/getAuth",
+      getIsDark: "ui/getIsDark"
     }),
 
     read_only: function() {

--- a/src/components/ui/msig-proposal.vue
+++ b/src/components/ui/msig-proposal.vue
@@ -529,7 +529,8 @@ export default {
       getIsCustodian: "user/getIsCustodian",
       getSettingByName: "user/getSettingByName",
       getAuth: "user/getAuth",
-      getIsDark: "ui/getIsDark"
+      getIsDark: "ui/getIsDark",
+      getCustodians: "dac/getCustodians"
     }),
 
     read_only: function() {
@@ -608,15 +609,21 @@ export default {
         ...this.msig.requested_approvals.map(a => a.actor)
       ]);
 
-      this.provided_approvals = this.msig.provided_approvals.map(pa => {
-        pa.avatar = avatars.find(p => p.account === pa.actor);
-        return pa;
-      });
+      let cust_names = this.getCustodians.map(c => c.cust_name);
 
-      this.requested_approvals = this.msig.requested_approvals.map(ra => {
-        ra.avatar = avatars.find(p => p.account === ra.actor);
-        return ra;
-      });
+      this.provided_approvals = this.msig.provided_approvals
+        .filter(ra => cust_names.includes(ra.actor))
+        .map(pa => {
+          pa.avatar = avatars.find(p => p.account === pa.actor);
+          return pa;
+        });
+
+      this.requested_approvals = this.msig.requested_approvals
+        .filter(ra => cust_names.includes(ra.actor))
+        .map(ra => {
+          ra.avatar = avatars.find(p => p.account === ra.actor);
+          return ra;
+        });
     },
 
     //approve a proposal via msig relay {"proposer":0,"proposal_name":0,"level":0}

--- a/src/components/ui/period-timer.vue
+++ b/src/components/ui/period-timer.vue
@@ -46,10 +46,13 @@ export default {
         this.getCustodianConfig.periodlength &&
         this.getCustodianState.lastperiodtime
       ) {
-        let end = addToDate(
-          new Date(this.getCustodianState.lastperiodtime * 1000),
-          { seconds: this.getCustodianConfig.periodlength }
-        );
+        let lastperiodtime = this.getCustodianState.lastperiodtime;
+        if (Number.isInteger(lastperiodtime)) {
+          lastperiodtime = lastperiodtime * 1000;
+        }
+        let end = addToDate(new Date(lastperiodtime), {
+          seconds: this.getCustodianConfig.periodlength
+        });
         return date.formatDate(end, "YYYY-MM-DD HH:mm:ss");
       }
     }

--- a/src/components/ui/period-timer.vue
+++ b/src/components/ui/period-timer.vue
@@ -46,11 +46,14 @@ export default {
         this.getCustodianConfig.periodlength &&
         this.getCustodianState.lastperiodtime
       ) {
+        // let lastperiodtime = this.getCustodianState.lastperiodtime;
         let lastperiodtime = this.getCustodianState.lastperiodtime;
         if (Number.isInteger(lastperiodtime)) {
-          lastperiodtime = lastperiodtime * 1000;
+          lastperiodtime = new Date(lastperiodtime * 1000);
+        } else {
+          lastperiodtime = new Date(lastperiodtime);
         }
-        let end = addToDate(new Date(lastperiodtime), {
+        let end = addToDate(lastperiodtime, {
           seconds: this.getCustodianConfig.periodlength
         });
         return date.formatDate(end, "YYYY-MM-DD HH:mm:ss");

--- a/src/components/ui/period-timer.vue
+++ b/src/components/ui/period-timer.vue
@@ -46,11 +46,13 @@ export default {
         this.getCustodianConfig.periodlength &&
         this.getCustodianState.lastperiodtime
       ) {
-        // let lastperiodtime = this.getCustodianState.lastperiodtime;
+        // let lastperiodtime = "2019-05-06T18:34:46";
         let lastperiodtime = this.getCustodianState.lastperiodtime;
         if (Number.isInteger(lastperiodtime)) {
           lastperiodtime = new Date(lastperiodtime * 1000);
         } else {
+          // example "2019-05-06 18:34:46"
+          lastperiodtime = lastperiodtime.replace("T", " ") + " UTC";
           lastperiodtime = new Date(lastperiodtime);
         }
         let end = addToDate(lastperiodtime, {

--- a/src/i18n/en_US/index.json
+++ b/src/i18n/en_US/index.json
@@ -12,6 +12,7 @@
   "constitution": {
     "direct_link": "Direct Link",
     "hash": "Hash",
+    "not_signed_message": "You aren't a member of {dacname} until you have agreed to the constitution",
     "signed_message": "You have signed the constitution!",
     "switch_contrast": "Switch Contrast"
   },

--- a/src/i18n/en_US/index.json
+++ b/src/i18n/en_US/index.json
@@ -13,8 +13,10 @@
     "direct_link": "Direct Link",
     "hash": "Hash",
     "not_signed_message": "You aren't a member of {dacname} until you have agreed to the constitution",
+    "sign": "sign",
     "signed_message": "You have signed the constitution!",
-    "switch_contrast": "Switch Contrast"
+    "switch_contrast": "Switch Contrast",
+    "unsign": "unsign"
   },
   "contract_errors": {
     "BURN_INVALID_QTY_": "invalid quantity",

--- a/src/pages/constitution.vue
+++ b/src/pages/constitution.vue
@@ -97,7 +97,7 @@
                 class="on-right"
                 @click="signConstitution()"
                 color="primary"
-                label="Sign"
+                :label="$t('constitution.sign')"
               />
               <div
                 v-if="!needSignature"
@@ -110,7 +110,7 @@
                 class="on-right"
                 @click="unRegister()"
                 color="primary"
-                label="unsign"
+                :label="$t('constitution.unsign')"
               />
             </div>
           </div>

--- a/src/pages/constitution.vue
+++ b/src/pages/constitution.vue
@@ -85,11 +85,19 @@
 
             <!-- <q-item-side left>dd</q-item-side> -->
             <div class="row justify-end items-center">
+              <div v-if="needSignature" class="text-negative q-caption q-my-sm">
+                {{
+                  $t("constitution.not_signed_message", {
+                    dacname: $configFile.get("dacname")
+                  })
+                }}
+              </div>
               <q-btn
                 v-if="needSignature"
+                class="on-right"
                 @click="signConstitution()"
                 color="primary"
-                label="register"
+                label="Sign"
               />
               <div
                 v-if="!needSignature"
@@ -102,7 +110,7 @@
                 class="on-right"
                 @click="unRegister()"
                 color="primary"
-                label="unregister"
+                label="unsign"
               />
             </div>
           </div>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -125,8 +125,7 @@
         <div class="bg-bg1 round-borders shadow-5 q-pa-md full-height bg-logo">
           <period-timer />
           <div class="text-text2 q-mt-md">
-            A new custodian board will be elected every 7 days when the timer
-            expires.
+            A new custodian board will be elected when the timer expires.
           </div>
         </div>
       </div>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -31,18 +31,17 @@
                 <div class="row justify-start items-center">
                   <span class="q-headline text-text1 q-mr-sm">My Votes</span>
                   <q-btn
-                    v-if="getDacVotes"
                     class="animate-pop"
                     dense
                     size="sm"
                     color="bg2"
                     to="/vote-custodians"
-                    label="change votes"
+                    :label="getDacVotes ? 'change votes' : 'vote'"
                   />
                 </div>
               </q-item-tile>
               <q-item-tile>
-                <div class="row">
+                <div v-if="getDacVotes" class="row">
                   <div
                     v-for="(vote, i) in getDacVotes"
                     class="column"
@@ -55,6 +54,9 @@
                     />
                   </div>
                 </div>
+                <div v-else class="text-text2">
+                  You have not voted yet.
+                </div>
               </q-item-tile>
             </q-item-main>
           </q-item>
@@ -62,7 +64,7 @@
       </div>
       <!-- box profile -->
 
-      <div class="col-xs-12 col-md-6 col-xl-4">
+      <div v-if="getIsCustodian" class="col-xs-12 col-md-6 col-xl-4">
         <div
           class="bg-bg1 round-borders shadow-5 q-pa-md bg-logo dashboard-box full-height"
         >
@@ -173,7 +175,8 @@ export default {
       getDacVotes: "user/getDacVotes",
       getLocal_storage_version: "global/getLocal_storage_version",
       getDapp_version: "global/getDapp_version",
-      getActiveNetworkName: "global/getActiveNetworkName"
+      getActiveNetworkName: "global/getActiveNetworkName",
+      getIsCustodian: "user/getIsCustodian"
     })
   },
   data() {

--- a/src/pages/manage-candidateship.vue
+++ b/src/pages/manage-candidateship.vue
@@ -184,8 +184,10 @@
         </div>
 
         <div class="row justify-end q-mt-md">
+          {{ verifyAndGetRequestedPay }} {{ verifyAndGetStakeAmount }}
+          {{ checkAlreadyStaked }} {{ allowRegister }}
           <q-btn
-            :disabled="!verifyAndGetRequestedPay || !verifyAndGetStakeAmount"
+            :disabled="!allowRegister"
             class="animate-pop"
             color="primary"
             @click="registerAsCandidtate"
@@ -320,6 +322,25 @@ export default {
         console.log("stake out of range");
         return false;
       }
+    },
+    checkAlreadyStaked() {
+      if (
+        this.getIsCandidate &&
+        this.assetToNumber(this.getIsCandidate.locked_tokens)
+      ) {
+        return (
+          this.assetToNumber(this.getIsCandidate.locked_tokens) >=
+          this.assetToNumber(this.getCustodianConfig.lockupasset)
+        );
+      } else {
+        return false;
+      }
+    },
+    allowRegister() {
+      return (
+        this.verifyAndGetRequestedPay &&
+        (this.verifyAndGetStakeAmount || this.checkAlreadyStaked)
+      );
     }
   },
 
@@ -355,7 +376,9 @@ export default {
 
       let actions = [registeraction];
 
-      actions.unshift(stakeaction);
+      if (!this.checkAlreadyStaked) {
+        actions.unshift(stakeaction);
+      }
 
       let result = await this.$store.dispatch("user/transact", {
         actions: actions

--- a/src/pages/manage-candidateship.vue
+++ b/src/pages/manage-candidateship.vue
@@ -184,8 +184,6 @@
         </div>
 
         <div class="row justify-end q-mt-md">
-          {{ verifyAndGetRequestedPay }} {{ verifyAndGetStakeAmount }}
-          {{ checkAlreadyStaked }} {{ allowRegister }}
           <q-btn
             :disabled="!allowRegister"
             class="animate-pop"

--- a/src/plugins/config-loader.js
+++ b/src/plugins/config-loader.js
@@ -1,11 +1,36 @@
 require("../assets/icon-fonts/eosdac-iconfont-v1-9/styles.css");
 require("../assets/icon-fonts/extended_material_icons/css/materialdesignicons.css");
 
+function styledConsoleLog() {
+  let argArray = [];
+  if (arguments.length) {
+    const startTagRe = /<span\s+style=(['"])([^'"]*)\1\s*>/gi;
+    const endTagRe = /<\/span>/gi;
+    let reResultArray;
+    argArray.push(
+      arguments[0].replace(startTagRe, "%c").replace(endTagRe, "%c")
+    );
+    while ((reResultArray = startTagRe.exec(arguments[0]))) {
+      argArray.push(reResultArray[2]);
+      argArray.push("");
+    }
+    for (var j = 1; j < arguments.length; j++) {
+      argArray.push(arguments[j]);
+    }
+  }
+  console.log.apply(console, argArray);
+}
+
 class ConfigLoader {
   constructor(networkname) {
     this.configFile = require(`../extensions/statics/config/config.${networkname}.json`);
     this.icon = require(`../extensions/statics/config/iconmap.json`);
-    // store.commit('global/setConfig', this.configFile);
+
+    styledConsoleLog(
+      `<span style="color:white;background-color:hsl(268, 87%, 53%); font-size:21px; padding:5px;">Welcome To the ${this.get(
+        "dacname"
+      )} Member Client </span><span style="color:black; font-size:12px;">Pasting code in the console can be dangerous </span>`
+    );
   }
 
   get(configquery) {
@@ -97,5 +122,3 @@ export default ({ Vue, store }) => {
   store.commit("global/setNode", config.get("defaultnode"));
   Vue.prototype.$configFile = config;
 };
-
-// export {configFile}

--- a/src/plugins/profile-cache.js
+++ b/src/plugins/profile-cache.js
@@ -58,9 +58,15 @@ class ProfileCache {
 
   async fetchProfiles(accountnames) {
     let url = this.config.get("memberclientstateapi").replace(/\/+$/, "");
-
-    return axios
-      .get(`${url}/profile?account=${accountnames.join(",")}`)
+    // let dacname = "eosdac"; //this.config.get("dacname");
+    let params = { account: accountnames.join(",") };
+    const header = { "X-DAC-Name": this.config.get("dacname").toLowerCase() };
+    return axios({
+      method: "get",
+      url: `${url}/profile`,
+      params: params,
+      headers: header
+    })
       .then(r => {
         console.log("fetched new profiles", r.data.results.length);
         let p = r.data.results;
@@ -68,7 +74,7 @@ class ProfileCache {
         return p;
       })
       .catch(e => {
-        console.log("could not load profile file");
+        console.log("error during api request.", e);
         return false;
       });
   }

--- a/src/store/dac/actions.js
+++ b/src/store/dac/actions.js
@@ -16,6 +16,7 @@ export async function initRoutine({ state, commit, dispatch }, vm) {
   commit("setIsLoaded", true);
   //load in background
   dispatch("fetchActiveCandidates");
+  dispatch("fetchDacAdmins");
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -70,6 +71,21 @@ export async function fetchActiveCandidates({ state, commit, dispatch }) {
   console.log("active candidates with profile", candidates);
   commit("setCandidates", candidates);
   return candidates;
+}
+
+export async function fetchDacAdmins({ commit, dispatch }) {
+  const api = await dispatch("global/getEosApi", false, { root: true });
+  let res = await api.getAccount(this._vm.$configFile.get("authaccountname"));
+  if (res && res.permissions) {
+    let admins = res.permissions
+      .find(p => p.perm_name == "admin")
+      .required_auth.accounts.map(a => a.permission.actor);
+
+    if (admins && admins.length) {
+      console.log("Dac Admins", admins);
+      commit("setDacAdmins", admins);
+    }
+  }
 }
 
 export async function fetchApprovalsFromProposal({ dispatch }, payload) {

--- a/src/store/dac/actions.js
+++ b/src/store/dac/actions.js
@@ -77,9 +77,9 @@ export async function fetchDacAdmins({ commit, dispatch }) {
   const api = await dispatch("global/getEosApi", false, { root: true });
   let res = await api.getAccount(this._vm.$configFile.get("authaccountname"));
   if (res && res.permissions) {
-    let admins = res.permissions
-      .find(p => p.perm_name == "admin")
-      .required_auth.accounts.map(a => a.permission.actor);
+    let admins = res.permissions.find(p => p.perm_name == "admin");
+    if (!admins) return;
+    admins = admins.required_auth.accounts.map(a => a.permission.actor);
 
     if (admins && admins.length) {
       console.log("Dac Admins", admins);

--- a/src/store/dac/actions.js
+++ b/src/store/dac/actions.js
@@ -120,8 +120,16 @@ export async function fetchWpConfig({ commit, dispatch, state }) {
 
 export async function fetchWorkerProposals({}, payload = {}) {
   let url = this._vm.$configFile.get("memberclientstateapi");
-  return this._vm.$axios
-    .get(url + "/proposals", { params: payload })
+  const header = {
+    "X-DAC-Name": this._vm.$configFile.get("dacname").toLowerCase()
+  };
+  return this._vm
+    .$axios({
+      method: "get",
+      url: `${url}/proposals`,
+      params: payload,
+      headers: header
+    })
     .then(r => {
       // console.log(r.data)
       return r.data;
@@ -135,8 +143,16 @@ export async function fetchWorkerProposals({}, payload = {}) {
 export async function fetchMsigProposals({}, payload = {}) {
   // {status: 1, limit:0, skip: 1}
   let url = this._vm.$configFile.get("memberclientstateapi");
-  return this._vm.$axios
-    .get(url + "/msig_proposals", { params: payload })
+  const header = {
+    "X-DAC-Name": this._vm.$configFile.get("dacname").toLowerCase()
+  };
+  return this._vm
+    .$axios({
+      method: "get",
+      url: `${url}/msig_proposals`,
+      params: payload,
+      headers: header
+    })
     .then(r => {
       // console.log(r.data)
       return r.data;
@@ -150,8 +166,16 @@ export async function fetchMsigProposals({}, payload = {}) {
 export async function fetchTokenTimeLine({}, payload = {}) {
   // {account: 'piecesnbitss', contract:'kasdactokens', symbol:'KASDAC', start_block:10000000, end_block:17000000}
   let url = this._vm.$configFile.get("memberclientstateapi");
-  return this._vm.$axios
-    .get(url + "/balance_timeline", { params: payload })
+  const header = {
+    "X-DAC-Name": this._vm.$configFile.get("dacname").toLowerCase()
+  };
+  return this._vm
+    .$axios({
+      method: "get",
+      url: `${url}/balance_timeline`,
+      params: payload,
+      headers: header
+    })
     .then(r => {
       // console.log(r.data)
       return r.data;

--- a/src/store/dac/getters.js
+++ b/src/store/dac/getters.js
@@ -19,6 +19,10 @@ export function getLatestMemberTerm(state) {
   return state.memberTerms.slice(-1)[0];
 }
 
+export function getDacAdmins(state) {
+  return state.dacAdmins;
+}
+
 export function getlatestTermsUrl(state) {
   return state.latestTermsUrl;
 }

--- a/src/store/dac/mutations.js
+++ b/src/store/dac/mutations.js
@@ -15,6 +15,10 @@ export function setCustodians(state, payload) {
   state.custodians = payload;
 }
 
+export function setDacAdmins(state, payload) {
+  state.dacAdmins = payload;
+}
+
 export function setCustodianConfig(state, payload) {
   state.custodianConfig = payload;
 }

--- a/src/store/dac/state.js
+++ b/src/store/dac/state.js
@@ -4,7 +4,7 @@ export default {
   memberTerms: null,
   custodians: null,
   candidates: null,
-  dacAdmins: null,
+  dacAdmins: [],
   custodianConfig: {
     lockupasset: null,
     maxvotes: null,

--- a/src/store/dac/state.js
+++ b/src/store/dac/state.js
@@ -4,6 +4,7 @@ export default {
   memberTerms: null,
   custodians: null,
   candidates: null,
+  dacAdmins: null,
   custodianConfig: {
     lockupasset: null,
     maxvotes: null,

--- a/src/store/user/getters.js
+++ b/src/store/user/getters.js
@@ -79,12 +79,12 @@ export function getCatDelegations(state) {
 }
 
 export function getIsCustodian(state, getters, rootState) {
-  const admins = ["piecesnbitss", "pramodeosdac"];
+  // const admins = ["piecesnbitss", "pramodeosdac"];
   if (rootState.dac.custodians && getters.getAccountName) {
     let res = rootState.dac.custodians.find(
       c => c.cust_name == getters.getAccountName
     );
-    if (res || admins.includes(state.accountName)) {
+    if (res || rootState.dac.dacAdmins.includes(state.accountName)) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
* Adding markdown support for the MSIG proposal description.
* For multisig proposals, we now [double the number of accounts](https://github.com/eosdac/eosdac-client/compare/dev?expand=1#diff-48475ed3bd2c93b84540f1d4f42f3ffdR619) on the msig so if new custodians are elected, they can participate in the voting for existing proposals.
* Some display improvements to the MSIG display to include the expiration date and the proposal name.
* When re-registering as a custodian candidate, we now check if you've already staked the required EOSDAC tokens.
* Adding some improved styling (and a friendly warning) the console log output.
* Added support for a custodian admin who can, on behalf of a custodian, create multisignature proposals, but not vote on them.