### PR TITLE
Fix profile cache, account for inflight responses and use Promise.all…

### DIFF
--- a/src/plugins/profile-cache.js
+++ b/src/plugins/profile-cache.js
@@ -4,43 +4,30 @@ class ProfileCache {
   constructor(config) {
     console.log("profile cache initiated");
     this.config = config;
-    this.cache = [];
+    this.cache = new Map();
     this.default_avatar = "./branding/images/default-avatar.png";
+    this.request_queue = new Set();
+    this.inflight = new Set();
     let cache_life = 1000 * 60 * 60;
 
     if (cache_life) {
       setInterval(() => {
-        this.cache = [];
+        this.cache.clear();
         console.log("emptied cache");
       }, cache_life);
     }
+
+    setInterval(this.processQueue.bind(this), 300);
   }
 
   async getProfiles(accountnames, force_reload = false) {
     if (force_reload) this.removeFromCache(accountnames);
     //reduce requested accountnames
-    let profiles = accountnames.reduce(
-      (temp, accountname) => {
-        let t = this.inCache(accountname);
-        t ? temp.cached.push(t) : temp.fetch.push(accountname);
-        return temp;
-      },
-      { cached: [], fetch: [] }
-    );
+    let profiles = accountnames.map(accountname => {
+      return this.getPromise(accountname);
+    });
 
-    //fetch profiles only when not in cache
-    if (profiles.fetch.length) {
-      profiles.fetch = await this.fetchProfiles(profiles.fetch);
-      //remove http images
-      profiles.fetch.forEach(p => {
-        if (p.profile.image.startsWith("http:")) {
-          p.profile.image = "";
-        }
-      });
-    }
-
-    //return combined array of profiles
-    return [...profiles.cached, ...profiles.fetch];
+    return Promise.all(profiles);
   }
 
   async getAvatars(accountnames, force_reload = false) {
@@ -56,44 +43,84 @@ class ProfileCache {
     return avatars;
   }
 
+  async processQueue() {
+    if (this.request_queue.size) {
+      const names = Array.from(this.request_queue.values());
+      console.log(`Process queue`, names);
+      this.request_queue.clear();
+      this.inflight = new Set(names);
+      this.fetchProfiles(names);
+    }
+  }
+
+  async responseWrapper(resp, accountname) {
+    /*
+      After response is received, filter for only `accountname` and set the cache.  All other promises will resolve
+      once the cache is populated
+       */
+    const resp_data = await resp;
+    const profile_data = resp_data.data.results.filter(
+      a => a.account === accountname
+    )[0];
+    this.cache.set(accountname, profile_data);
+    this.inflight.delete(accountname);
+    return profile_data;
+  }
+
   async fetchProfiles(accountnames) {
     let url = this.config.get("memberclientstateapi");
     // let dacname = "eosdac"; //this.config.get("dacname");
     let params = { account: accountnames.join(",") };
     const header = { "X-DAC-Name": this.config.get("dacscope") };
-    return axios({
+    const resp = axios({
       method: "get",
       url: `${url}/profile`,
       params: params,
       headers: header
-    })
-      .then(r => {
-        console.log("fetched new profiles", r.data.results.length);
-        let p = r.data.results;
-        this.cache = this.cache.concat(p);
-        return p;
-      })
-      .catch(e => {
-        console.log("error during api request.", e);
-        return false;
-      });
+    });
+
+    const retvals = accountnames.map(accountname => {
+      return this.responseWrapper(resp, accountname);
+    });
+
+    return retvals;
   }
 
-  inCache(accountname) {
-    let profile = this.cache.find(p => p.account == accountname);
-    if (profile) {
-      return profile;
-    } else {
-      return false;
-    }
+  async getPromise(accountname) {
+    /*
+      Returns a promise which will return the contents of the cache, if not in the cache then will add to the
+      request queue and resolve once that has been executed and in the cache
+       */
+    return new Promise((resolve, reject) => {
+      if (this.cache.has(accountname)) {
+        resolve(this.cache.get(accountname));
+      } else {
+        const interval_handler = () => {
+          if (this.cache.has(accountname)) {
+            resolve(this.cache.get(accountname));
+          } else if (!this.inflight.has(accountname)) {
+            this.request_queue.add(accountname);
+          }
+        };
+
+        interval_handler();
+        const ival = setInterval(interval_handler, 100);
+        setTimeout(() => {
+          if (!this.cache.has(accountname)) {
+            console.error(`Timeout fetching profile for ${accountname}`);
+          }
+          clearInterval(ival);
+        }, 10000);
+      }
+    });
   }
 
   removeFromCache(accountnames) {
-    this.cache = this.cache.filter(p => !accountnames.includes(p.account));
+    accountnames.forEach(account => this.cache.delete(account));
   }
 
   delete() {
-    this.cache = [];
+    this.cache.clear();
     console.log("Profile cache emptied");
   }
 }


### PR DESCRIPTION
…() to emulate previous responses to getProfiles

The member client profile cache didnt account for inflight requests so when many requests were made before the first request returned, they would send additional requests

This patch handles inflight requests so only a single request is made